### PR TITLE
Add Ability to Paste CT URL

### DIFF
--- a/app/src/main/java/com/example/column/MainActivity.kt
+++ b/app/src/main/java/com/example/column/MainActivity.kt
@@ -5,8 +5,13 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
+import android.widget.EditText
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var urlEditText: EditText;
+    // Either set test URL here or paste one into your Android device
+    private var defaultUrl = "<user url>"
+
     override fun onCreate(savedInstanceState: Bundle?) {
         window.setFlags(
             WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN
@@ -14,12 +19,23 @@ class MainActivity : AppCompatActivity() {
 
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        urlEditText = findViewById(R.id.urlEditText)
     }
 
     fun launchWebView(view: View) {
         val intent = Intent(applicationContext, WebViewActivity::class.java)
-        val url = "<user url>"
+        val url = getUrlText()
         intent.putExtra("url", url)
         startActivity(intent)
+    }
+
+    private fun getUrlText(): String {
+        var urlText = urlEditText.text.toString()
+
+        return if (urlText.isNullOrEmpty()) {
+            return defaultUrl
+        } else {
+            urlText
+        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -9,19 +9,39 @@
     android:paddingRight="10dp"
     tools:context=".MainActivity">
 
-    <Button
-        android:id="@+id/button"
+    <TextView
+        android:id="@+id/titleTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="CT Android Tester"
+        android:textSize="24sp"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="40dp"/>
+
+    <EditText
+        android:id="@+id/urlEditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/titleTextView"
+        android:hint="Paste Column Tax URL here"
+        android:inputType="textMultiLine"
+        android:maxLines="12"
+        android:minHeight="200dp"
+        android:layout_marginTop="20dp"/>
+
+    <Button
+        android:id="@+id/button"
         android:background="#0070FF"
         android:onClick="launchWebView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/urlEditText"
         android:paddingLeft="10dp"
         android:paddingRight="10dp"
-        android:text="Open Column"
-        android:textAllCaps="false"
+        android:text="Open Column URL"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:textAllCaps="false"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="20dp"/>
+
+</RelativeLayout>


### PR DESCRIPTION
Makes it easier to try out the sample by getting a CT URL and pasting it in

<img width="252" alt="Screen Shot 2023-11-29 at 3 29 01 PM" src="https://github.com/column-tax/column-android-sample/assets/12505097/50473f11-3362-460c-a628-40694f9544df">
